### PR TITLE
Bumped Vuetify to 2.3.10 and Security Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1065,10 +1065,61 @@
                 "glob-to-regexp": "^0.3.0"
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            },
+            "dependencies": {
+                "@nodelib/fs.stat": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+                    "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+                    "dev": true
+                }
+            }
+        },
         "@nodelib/fs.stat": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
+        "@npmcli/move-file": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
+            "integrity": "sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^1.0.4"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                }
+            }
+        },
+        "@popperjs/core": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.2.tgz",
+            "integrity": "sha512-tVkIU9JQw5fYPxLQgok/a7I6J1eEZ79svwQGpe2mb3jlVsPADOleefOnQBiS/takK7jQuNeswCUicMH1VWVziA==",
             "dev": true
         },
         "@soda/friendly-errors-webpack-plugin": {
@@ -1130,26 +1181,20 @@
             "integrity": "sha512-9GvTek+7cVw7r+L7TNGOG1astZJWXz2h5q4BqMXl28KN+24iSCm1xo+RhZOZvwdT3bzNe9hD7riJc/lBoO7mgg==",
             "dev": true
         },
+        "@tippyjs/react": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.1.0.tgz",
+            "integrity": "sha512-g6Dpm46edr9T9z+BYxd/eJZa6QMFc4T4z5xrztxVlkti7AhNYf7OaE6b3Nh+boUZZ9wn8xkNq9VrQM5K4huwnQ==",
+            "dev": true,
+            "requires": {
+                "tippy.js": "^6.2.0"
+            }
+        },
         "@types/anymatch": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
             "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
             "dev": true
-        },
-        "@types/babel-types": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
-            "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==",
-            "dev": true
-        },
-        "@types/babylon": {
-            "version": "6.16.5",
-            "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
-            "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
-            "dev": true,
-            "requires": {
-                "@types/babel-types": "*"
-            }
         },
         "@types/color-name": {
             "version": "1.1.1",
@@ -1211,15 +1256,15 @@
             "dev": true
         },
         "@types/tapable": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.5.tgz",
-            "integrity": "sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+            "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
             "dev": true
         },
         "@types/uglify-js": {
-            "version": "3.9.2",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.2.tgz",
-            "integrity": "sha512-d6dIfpPbF+8B7WiCi2ELY7m0w1joD8cRW4ms88Emdb2w062NeEpbNCeWwVCgzLRpVG+5e74VFSg4rgJ2xXjEiQ==",
+            "version": "3.9.3",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+            "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
             "dev": true,
             "requires": {
                 "source-map": "^0.6.1"
@@ -1240,9 +1285,9 @@
             "dev": true
         },
         "@types/webpack": {
-            "version": "4.41.15",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.15.tgz",
-            "integrity": "sha512-JP9plf6b9BkAFRV71JXaqsbritf7P14EnLYu6s6tepW5Ci0wD9EisyJpOOAdNy0fOWuPMnWAY+vUgI0pz0klOw==",
+            "version": "4.41.22",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+            "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
             "dev": true,
             "requires": {
                 "@types/anymatch": "*",
@@ -1262,20 +1307,20 @@
             }
         },
         "@types/webpack-sources": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.7.tgz",
-            "integrity": "sha512-XyaHrJILjK1VHVC4aVlKsdNN5KBTwufMb43cQs+flGxtPAf/1Qwl8+Q0tp5BwEGaI8D6XT1L+9bSWXckgkjTLw==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
+            "integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
                 "@types/source-list-map": "*",
-                "source-map": "^0.6.1"
+                "source-map": "^0.7.3"
             },
             "dependencies": {
                 "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                     "dev": true
                 }
             }
@@ -1751,6 +1796,166 @@
                 }
             }
         },
+        "@vue/compiler-core": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.0.0.tgz",
+            "integrity": "sha512-XqPC7vdv4rFE77S71oCHmT1K4Ks3WE2Gi6Lr4B5wn0Idmp+NyQQBUHsCNieMDRiEpgtJrw+yOHslrsV0AfAsfQ==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.11.5",
+                "@babel/types": "^7.11.5",
+                "@vue/shared": "3.0.0",
+                "estree-walker": "^2.0.1",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/parser": {
+                    "version": "7.11.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+                    "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.11.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+                    "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "estree-walker": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+                    "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "@vue/compiler-dom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.0.0.tgz",
+            "integrity": "sha512-ukDEGOP8P7lCPyStuM3F2iD5w2QPgUu2xwCW2XNeqPjFKIlR2xMsWjy4raI/cLjN6W16GtlMFaZdK8tLj5PRog==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-core": "3.0.0",
+                "@vue/shared": "3.0.0"
+            }
+        },
+        "@vue/compiler-sfc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.0.0.tgz",
+            "integrity": "sha512-1Bn4L5jNRm6tlb79YwqYUGGe+Yc9PRoRSJi67NJX6icdhf84+tRMtESbx1zCLL9QixQXu2+7aLkXHxvh4RpqAA==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.11.5",
+                "@babel/types": "^7.11.5",
+                "@vue/compiler-core": "3.0.0",
+                "@vue/compiler-dom": "3.0.0",
+                "@vue/compiler-ssr": "3.0.0",
+                "@vue/shared": "3.0.0",
+                "consolidate": "^0.16.0",
+                "estree-walker": "^2.0.1",
+                "hash-sum": "^2.0.0",
+                "lru-cache": "^5.1.1",
+                "magic-string": "^0.25.7",
+                "merge-source-map": "^1.1.0",
+                "postcss": "^7.0.32",
+                "postcss-modules": "^3.2.2",
+                "postcss-selector-parser": "^6.0.2",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "@babel/helper-validator-identifier": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+                    "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+                    "dev": true
+                },
+                "@babel/parser": {
+                    "version": "7.11.5",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+                    "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+                    "dev": true
+                },
+                "@babel/types": {
+                    "version": "7.11.5",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+                    "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.10.4",
+                        "lodash": "^4.17.19",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "consolidate": {
+                    "version": "0.16.0",
+                    "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
+                    "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
+                    "dev": true,
+                    "requires": {
+                        "bluebird": "^3.7.2"
+                    }
+                },
+                "estree-walker": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+                    "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+                    "dev": true
+                },
+                "postcss": {
+                    "version": "7.0.34",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
+                    "integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@vue/compiler-ssr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.0.0.tgz",
+            "integrity": "sha512-Er41F9ZFyKB3YnNbE6JSTIGCVWve3NAQimgDOk4uP42OnckxBYKGBTutDeFNeqUZBMu/9vRHYrxlGFC9Z5jBVQ==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-dom": "3.0.0",
+                "@vue/shared": "3.0.0"
+            }
+        },
         "@vue/component-compiler-utils": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.1.2.tgz",
@@ -1802,6 +2007,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.1.tgz",
             "integrity": "sha512-8VCoJeeH8tCkzhkpfOkt+abALQkS11OIHhte5MBzYaKMTqK0A3ZAKEUVAffsOklhEv7t0yrQt696Opnu9oAx+w==",
+            "dev": true
+        },
+        "@vue/shared": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.0.0.tgz",
+            "integrity": "sha512-4XWL/avABGxU2E2ZF1eZq3Tj7fvksCMssDZUHOykBIMmh5d+KcAnQMC5XHMhtnA0NAvktYsA2YpdsVwVmhWzvA==",
             "dev": true
         },
         "@vue/web-component-wrapper": {
@@ -2028,23 +2239,6 @@
             "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
             "dev": true
         },
-        "acorn-globals": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-            "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-            "dev": true,
-            "requires": {
-                "acorn": "^4.0.4"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "4.0.13",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-                    "dev": true
-                }
-            }
-        },
         "acorn-jsx": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
@@ -2104,28 +2298,6 @@
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
             "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
             "dev": true
-        },
-        "align-text": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-            "dev": true,
-            "requires": {
-                "kind-of": "^3.0.2",
-                "longest": "^1.0.1",
-                "repeat-string": "^1.5.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
         },
         "alphanum-sort": {
             "version": "1.0.2",
@@ -2303,14 +2475,15 @@
             }
         },
         "asn1.js": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
             },
             "dependencies": {
                 "bn.js": {
@@ -2348,6 +2521,12 @@
                 }
             }
         },
+        "assert-never": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+            "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
+            "dev": true
+        },
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2361,10 +2540,21 @@
             "dev": true
         },
         "ast-types": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-            "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
-            "dev": true
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.0.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+                    "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+                    "dev": true
+                }
+            }
         },
         "astral-regex": {
             "version": "1.0.0",
@@ -2551,31 +2741,14 @@
                 }
             }
         },
-        "babel-types": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+        "babel-walk": {
+            "version": "3.0.0-canary-5",
+            "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+            "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
-            },
-            "dependencies": {
-                "to-fast-properties": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-                    "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-                    "dev": true
-                }
+                "@babel/types": "^7.9.6"
             }
-        },
-        "babylon": {
-            "version": "6.18.0",
-            "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-            "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-            "dev": true
         },
         "bail": {
             "version": "1.0.5",
@@ -2696,9 +2869,9 @@
             "dev": true
         },
         "bn.js": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-            "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+            "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
             "dev": true
         },
         "body-parser": {
@@ -2894,16 +3067,16 @@
             }
         },
         "browserify-sign": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
-            "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+            "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
             "dev": true,
             "requires": {
                 "bn.js": "^5.1.1",
                 "browserify-rsa": "^4.0.1",
                 "create-hash": "^1.2.0",
                 "create-hmac": "^1.1.7",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "inherits": "^2.0.4",
                 "parse-asn1": "^5.1.5",
                 "readable-stream": "^3.6.0",
@@ -2951,26 +3124,33 @@
             }
         },
         "buble": {
-            "version": "0.19.8",
-            "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
-            "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/buble/-/buble-0.20.0.tgz",
+            "integrity": "sha512-/1gnaMQE8xvd5qsNBl+iTuyjJ9XxeaVxAMF86dQ4EyxFJOZtsgOS8Ra+7WHgZTam5IFDtt4BguN0sH0tVTKrOw==",
             "dev": true,
             "requires": {
-                "acorn": "^6.1.1",
+                "acorn": "^6.4.1",
                 "acorn-dynamic-import": "^4.0.0",
-                "acorn-jsx": "^5.0.1",
+                "acorn-jsx": "^5.2.0",
                 "chalk": "^2.4.2",
-                "magic-string": "^0.25.3",
-                "minimist": "^1.2.0",
-                "os-homedir": "^2.0.0",
-                "regexpu-core": "^4.5.4"
+                "magic-string": "^0.25.7",
+                "minimist": "^1.2.5",
+                "regexpu-core": "4.5.4"
             },
             "dependencies": {
-                "os-homedir": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
-                    "integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q==",
-                    "dev": true
+                "regexpu-core": {
+                    "version": "4.5.4",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
+                    "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.0",
+                        "regenerate-unicode-properties": "^8.0.2",
+                        "regjsgen": "^0.5.0",
+                        "regjsparser": "^0.6.0",
+                        "unicode-match-property-ecmascript": "^1.0.4",
+                        "unicode-match-property-value-ecmascript": "^1.1.0"
+                    }
                 }
             }
         },
@@ -3349,16 +3529,6 @@
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
             "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
             "dev": true
-        },
-        "center-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-            "dev": true,
-            "requires": {
-                "align-text": "^0.1.3",
-                "lazy-cache": "^1.0.3"
-            }
         },
         "chalk": {
             "version": "2.4.2",
@@ -3825,9 +3995,9 @@
             "dev": true
         },
         "codemirror": {
-            "version": "5.54.0",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.54.0.tgz",
-            "integrity": "sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q==",
+            "version": "5.58.1",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.1.tgz",
+            "integrity": "sha512-UGb/ueu20U4xqWk8hZB3xIfV2/SFqnSLYONiM3wTMDqko0bsYrsAkGGhqUzbRkYm89aBKPyHtuNEbVWF9FTFzw==",
             "dev": true
         },
         "collapse-white-space": {
@@ -4015,9 +4185,9 @@
             },
             "dependencies": {
                 "dot-prop": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+                    "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
                     "dev": true,
                     "requires": {
                         "is-obj": "^1.0.0"
@@ -4068,15 +4238,13 @@
             }
         },
         "constantinople": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
-            "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
+            "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
             "dev": true,
             "requires": {
-                "@types/babel-types": "^7.0.0",
-                "@types/babylon": "^6.16.2",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0"
+                "@babel/parser": "^7.6.0",
+                "@babel/types": "^7.6.1"
             }
         },
         "constants-browserify": {
@@ -4142,9 +4310,9 @@
             "dev": true
         },
         "copy-webpack-plugin": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-            "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+            "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
             "dev": true,
             "requires": {
                 "cacache": "^12.0.3",
@@ -4157,7 +4325,7 @@
                 "normalize-path": "^3.0.0",
                 "p-limit": "^2.2.1",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.2",
+                "serialize-javascript": "^4.0.0",
                 "webpack-log": "^2.0.0"
             },
             "dependencies": {
@@ -4309,13 +4477,13 @@
             }
         },
         "create-ecdh": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "elliptic": "^6.5.3"
             },
             "dependencies": {
                 "bn.js": {
@@ -4638,9 +4806,9 @@
             }
         },
         "csstype": {
-            "version": "2.6.10",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-            "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+            "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
             "dev": true
         },
         "currently-unhandled": {
@@ -5403,9 +5571,9 @@
             }
         },
         "elliptic": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.4.0",
@@ -5453,9 +5621,9 @@
             }
         },
         "enhanced-resolve": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-            "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+            "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -5563,9 +5731,9 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-            "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
             "dev": true,
             "requires": {
                 "esprima": "^4.0.1",
@@ -5965,9 +6133,9 @@
             "dev": true
         },
         "events": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-            "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+            "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
             "dev": true
         },
         "eventsource": {
@@ -6293,6 +6461,21 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "fastest-levenshtein": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+            "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+            "dev": true
+        },
+        "fastq": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+            "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
         },
         "faye-websocket": {
             "version": "0.10.0",
@@ -6735,6 +6918,15 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
+        },
+        "generic-names": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
+            "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0"
+            }
         },
         "gensync": {
             "version": "1.0.0-beta.1",
@@ -7389,9 +7581,9 @@
             "dev": true
         },
         "hyphenate-style-name": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-            "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+            "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==",
             "dev": true
         },
         "iconv-lite": {
@@ -7933,19 +8125,19 @@
             "dev": true
         },
         "is-expression": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-            "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+            "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
             "dev": true,
             "requires": {
-                "acorn": "~4.0.2",
-                "object-assign": "^4.0.1"
+                "acorn": "^7.1.1",
+                "object-assign": "^4.1.1"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "4.0.13",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
                     "dev": true
                 }
             }
@@ -8377,78 +8569,78 @@
             }
         },
         "jss": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/jss/-/jss-10.1.1.tgz",
-            "integrity": "sha512-Xz3qgRUFlxbWk1czCZibUJqhVPObrZHxY3FPsjCXhDld4NOj1BgM14Ir5hVm+Qr6OLqVljjGvoMcCdXNOAbdkQ==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jss/-/jss-10.4.0.tgz",
+            "integrity": "sha512-l7EwdwhsDishXzqTc3lbsbyZ83tlUl5L/Hb16pHCvZliA9lRDdNBZmHzeJHP0sxqD0t1mrMmMR8XroR12JBYzw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "csstype": "^2.6.5",
+                "csstype": "^3.0.2",
                 "is-in-browser": "^1.1.3",
                 "tiny-warning": "^1.0.2"
             }
         },
         "jss-plugin-camel-case": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.1.1.tgz",
-            "integrity": "sha512-MDIaw8FeD5uFz1seQBKz4pnvDLnj5vIKV5hXSVdMaAVq13xR6SVTVWkIV/keyTs5txxTvzGJ9hXoxgd1WTUlBw==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.4.0.tgz",
+            "integrity": "sha512-9oDjsQ/AgdBbMyRjc06Kl3P8lDCSEts2vYZiPZfGAxbGCegqE4RnMob3mDaBby5H9vL9gWmyyImhLRWqIkRUCw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1",
                 "hyphenate-style-name": "^1.0.3",
-                "jss": "10.1.1"
+                "jss": "10.4.0"
             }
         },
         "jss-plugin-compose": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/jss-plugin-compose/-/jss-plugin-compose-10.1.1.tgz",
-            "integrity": "sha512-0fD+YVGk0fVnsLiNf7CG4Lv7lYwmNyeE62Fbccx8k1mMdFoE7he0hpx37tudsfKW2ArCE+hf4fmJDXPW8l6LBw==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-compose/-/jss-plugin-compose-10.4.0.tgz",
+            "integrity": "sha512-m1MKZQDH/48W2NHqgsfhYBAObVHzDzSCULLLqrc8nZh1fYGvEBUND82oqd6Jh95pJbMhTzx3E9st63MivEuvAw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.1.1",
+                "jss": "10.4.0",
                 "tiny-warning": "^1.0.2"
             }
         },
         "jss-plugin-default-unit": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.1.1.tgz",
-            "integrity": "sha512-UkeVCA/b3QEA4k0nIKS4uWXDCNmV73WLHdh2oDGZZc3GsQtlOCuiH3EkB/qI60v2MiCq356/SYWsDXt21yjwdg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.4.0.tgz",
+            "integrity": "sha512-BYJ+Y3RUYiMEgmlcYMLqwbA49DcSWsGgHpVmEEllTC8MK5iJ7++pT9TnKkKBnNZZxTV75ycyFCR5xeLSOzVm4A==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.1.1"
+                "jss": "10.4.0"
             }
         },
         "jss-plugin-global": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.1.1.tgz",
-            "integrity": "sha512-VBG3wRyi3Z8S4kMhm8rZV6caYBegsk+QnQZSVmrWw6GVOT/Z4FA7eyMu5SdkorDlG/HVpHh91oFN56O4R9m2VA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.4.0.tgz",
+            "integrity": "sha512-b8IHMJUmv29cidt3nI4bUI1+Mo5RZE37kqthaFpmxf5K7r2aAegGliAw4hXvA70ca6ckAoXMUl4SN/zxiRcRag==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.1.1"
+                "jss": "10.4.0"
             }
         },
         "jss-plugin-isolate": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/jss-plugin-isolate/-/jss-plugin-isolate-10.1.1.tgz",
-            "integrity": "sha512-MsytWLEETP8DpYat432g+PKH/oFXMJ7aYr9GQUEDkYXYlwDykL6k1gpAv8ZI0D+a9wiUXI9oka5tyZoR9qEgZA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-isolate/-/jss-plugin-isolate-10.4.0.tgz",
+            "integrity": "sha512-WR0IqdTNW0XgeLefqmOF9CS1GQlXszXv4tHCFH4AjGJG1dUk1VGGX1Wr+TKccFgViKgzXaTo6G96EPYjSGi8Kw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1",
                 "css-initials": "^0.3.1",
-                "jss": "10.1.1"
+                "jss": "10.4.0"
             }
         },
         "jss-plugin-nested": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.1.1.tgz",
-            "integrity": "sha512-ozEu7ZBSVrMYxSDplPX3H82XHNQk2DQEJ9TEyo7OVTPJ1hEieqjDFiOQOxXEj9z3PMqkylnUbvWIZRDKCFYw5Q==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.4.0.tgz",
+            "integrity": "sha512-cKgpeHIxAP0ygeWh+drpLbrxFiak6zzJ2toVRi/NmHbpkNaLjTLgePmOz5+67ln3qzJiPdXXJB1tbOyYKAP4Pw==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.3.1",
-                "jss": "10.1.1",
+                "jss": "10.4.0",
                 "tiny-warning": "^1.0.2"
             }
         },
@@ -8507,12 +8699,6 @@
             "requires": {
                 "launch-editor": "^2.2.1"
             }
-        },
-        "lazy-cache": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-            "dev": true
         },
         "leven": {
             "version": "3.1.0",
@@ -8697,9 +8883,15 @@
             }
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+            "dev": true
+        },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
             "dev": true
         },
         "lodash.defaultsdeep": {
@@ -8800,12 +8992,6 @@
             "version": "1.6.8",
             "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
             "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
-            "dev": true
-        },
-        "longest": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
             "dev": true
         },
         "longest-streak": {
@@ -9223,6 +9409,24 @@
                 "minipass": "^3.0.0"
             }
         },
+        "minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
+            }
+        },
         "mississippi": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -9286,9 +9490,9 @@
             }
         },
         "mri": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.5.tgz",
-            "integrity": "sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+            "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
             "dev": true
         },
         "ms": {
@@ -10172,14 +10376,13 @@
             }
         },
         "parse-asn1": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
+                "asn1.js": "^5.2.0",
                 "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
                 "evp_bytestokey": "^1.0.0",
                 "pbkdf2": "^3.0.3",
                 "safe-buffer": "^5.1.1"
@@ -10310,9 +10513,9 @@
             }
         },
         "pbkdf2": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-            "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+            "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
             "dev": true,
             "requires": {
                 "create-hash": "^1.1.2",
@@ -10745,6 +10948,51 @@
                 }
             }
         },
+        "postcss-modules": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-3.2.2.tgz",
+            "integrity": "sha512-JQ8IAqHELxC0N6tyCg2UF40pACY5oiL6UpiqqcIFRWqgDYO8B0jnxzoQ0EOpPrWXvcpu6BSbQU/3vSiq7w8Nhw==",
+            "dev": true,
+            "requires": {
+                "generic-names": "^2.0.1",
+                "icss-replace-symbols": "^1.1.0",
+                "lodash.camelcase": "^4.3.0",
+                "postcss": "^7.0.32",
+                "postcss-modules-extract-imports": "^2.0.0",
+                "postcss-modules-local-by-default": "^3.0.2",
+                "postcss-modules-scope": "^2.2.0",
+                "postcss-modules-values": "^3.0.0",
+                "string-hash": "^1.1.1"
+            },
+            "dependencies": {
+                "postcss": {
+                    "version": "7.0.34",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
+                    "integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "postcss-modules-extract-imports": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
@@ -11088,9 +11336,9 @@
             }
         },
         "prismjs": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
-            "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+            "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
             "dev": true,
             "requires": {
                 "clipboard": "^2.0.0"
@@ -11302,171 +11550,127 @@
             }
         },
         "pug": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
-            "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.0.tgz",
+            "integrity": "sha512-inmsJyFBSHZaiGLaguoFgJGViX0If6AcfcElimvwj9perqjDpUpw79UIEDZbWFmoGVidh08aoE+e8tVkjVJPCw==",
             "dev": true,
             "requires": {
-                "pug-code-gen": "^2.0.2",
-                "pug-filters": "^3.1.1",
-                "pug-lexer": "^4.1.0",
-                "pug-linker": "^3.0.6",
-                "pug-load": "^2.0.12",
-                "pug-parser": "^5.0.1",
-                "pug-runtime": "^2.0.5",
-                "pug-strip-comments": "^1.0.4"
+                "pug-code-gen": "^3.0.0",
+                "pug-filters": "^4.0.0",
+                "pug-lexer": "^5.0.0",
+                "pug-linker": "^4.0.0",
+                "pug-load": "^3.0.0",
+                "pug-parser": "^6.0.0",
+                "pug-runtime": "^3.0.0",
+                "pug-strip-comments": "^2.0.0"
             }
         },
         "pug-attrs": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
-            "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+            "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
             "dev": true,
             "requires": {
-                "constantinople": "^3.0.1",
-                "js-stringify": "^1.0.1",
-                "pug-runtime": "^2.0.5"
+                "constantinople": "^4.0.1",
+                "js-stringify": "^1.0.2",
+                "pug-runtime": "^3.0.0"
             }
         },
         "pug-code-gen": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
-            "integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.1.tgz",
+            "integrity": "sha512-xJIGvmXTQlkJllq6hqxxjRWcay2F9CU69TuAuiVZgHK0afOhG5txrQOcZyaPHBvSWCU/QQOqEp5XCH94rRZpBQ==",
             "dev": true,
             "requires": {
-                "constantinople": "^3.1.2",
+                "constantinople": "^4.0.1",
                 "doctypes": "^1.1.0",
-                "js-stringify": "^1.0.1",
-                "pug-attrs": "^2.0.4",
-                "pug-error": "^1.3.3",
-                "pug-runtime": "^2.0.5",
-                "void-elements": "^2.0.1",
-                "with": "^5.0.0"
+                "js-stringify": "^1.0.2",
+                "pug-attrs": "^3.0.0",
+                "pug-error": "^2.0.0",
+                "pug-runtime": "^3.0.0",
+                "void-elements": "^3.1.0",
+                "with": "^7.0.0"
             }
         },
         "pug-error": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
-            "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+            "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ==",
             "dev": true
         },
         "pug-filters": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
-            "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
+            "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
             "dev": true,
             "requires": {
-                "clean-css": "^4.1.11",
-                "constantinople": "^3.0.1",
+                "constantinople": "^4.0.1",
                 "jstransformer": "1.0.0",
-                "pug-error": "^1.3.3",
-                "pug-walk": "^1.1.8",
-                "resolve": "^1.1.6",
-                "uglify-js": "^2.6.1"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                    "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                    "dev": true,
-                    "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
-                        "wordwrap": "0.0.2"
-                    }
-                },
-                "uglify-js": {
-                    "version": "2.8.29",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                    "dev": true,
-                    "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
-                    }
-                },
-                "yargs": {
-                    "version": "3.10.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
-                        "window-size": "0.1.0"
-                    }
-                }
+                "pug-error": "^2.0.0",
+                "pug-walk": "^2.0.0",
+                "resolve": "^1.15.1"
             }
         },
         "pug-lexer": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
-            "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.0.tgz",
+            "integrity": "sha512-52xMk8nNpuyQ/M2wjZBN5gXQLIylaGkAoTk5Y1pBhVqaopaoj8Z0iVzpbFZAqitL4RHNVDZRnJDsqEYe99Ti0A==",
             "dev": true,
             "requires": {
-                "character-parser": "^2.1.1",
-                "is-expression": "^3.0.0",
-                "pug-error": "^1.3.3"
+                "character-parser": "^2.2.0",
+                "is-expression": "^4.0.0",
+                "pug-error": "^2.0.0"
             }
         },
         "pug-linker": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
-            "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
+            "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
             "dev": true,
             "requires": {
-                "pug-error": "^1.3.3",
-                "pug-walk": "^1.1.8"
+                "pug-error": "^2.0.0",
+                "pug-walk": "^2.0.0"
             }
         },
         "pug-load": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
-            "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
+            "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
             "dev": true,
             "requires": {
-                "object-assign": "^4.1.0",
-                "pug-walk": "^1.1.8"
+                "object-assign": "^4.1.1",
+                "pug-walk": "^2.0.0"
             }
         },
         "pug-parser": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
-            "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+            "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
             "dev": true,
             "requires": {
-                "pug-error": "^1.3.3",
-                "token-stream": "0.0.1"
+                "pug-error": "^2.0.0",
+                "token-stream": "1.0.0"
             }
         },
         "pug-runtime": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
-            "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.0.tgz",
+            "integrity": "sha512-GoEPcmQNnaTsePEdVA05bDpY+Op5VLHKayg08AQiqJBWU/yIaywEYv7TetC5dEQS3fzBBoyb2InDcZEg3mPTIA==",
             "dev": true
         },
         "pug-strip-comments": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
-            "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+            "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
             "dev": true,
             "requires": {
-                "pug-error": "^1.3.3"
+                "pug-error": "^2.0.0"
             }
         },
         "pug-walk": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
-            "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
+            "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
             "dev": true
         },
         "pump": {
@@ -11950,12 +12154,29 @@
             "dev": true
         },
         "react-docgen-displayname-handler": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/react-docgen-displayname-handler/-/react-docgen-displayname-handler-3.0.1.tgz",
-            "integrity": "sha512-fBH3OjzI7I4NkvQ/8PES48uO8jqeBwbH20yrdgJK76RllxKLHOO2oYeBxsCgY2Hhr0pUffITIc7RdWG+2R7+7g==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/react-docgen-displayname-handler/-/react-docgen-displayname-handler-3.0.2.tgz",
+            "integrity": "sha512-6SDJ2h6WuW0Kq6Vw34C3WmRfh1eYNDkaes9hxsmQ4fmX5tiI2lpR28J2cxlu4RpYrqBLrrtke6kWBef7pIL24w==",
             "dev": true,
             "requires": {
-                "ast-types": "0.13.3"
+                "ast-types": "0.14.2"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.14.2",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+                    "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.0.1"
+                    }
+                },
+                "tslib": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+                    "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+                    "dev": true
+                }
             }
         },
         "react-dom": {
@@ -11977,18 +12198,18 @@
             "dev": true
         },
         "react-group": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.6.tgz",
-            "integrity": "sha1-jdfADDs10FzhZAIUWLsH1YDjABo=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/react-group/-/react-group-3.0.2.tgz",
+            "integrity": "sha512-0Jy99MD27jHSJ0PeynomUM0WArxywdcqQUKLttBWV6KYH+zlKWT/RhDwVxrODtMkRxf644BzuJFie1Hvfun7jA==",
             "dev": true,
             "requires": {
-                "prop-types": "^15.6.0"
+                "prop-types": "^15.7.2"
             }
         },
         "react-icons": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.10.0.tgz",
-            "integrity": "sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.11.0.tgz",
+            "integrity": "sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0"
@@ -12013,27 +12234,29 @@
             "dev": true
         },
         "react-styleguidist": {
-            "version": "11.0.8",
-            "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-11.0.8.tgz",
-            "integrity": "sha512-ckqBfipqgFmCl5/Lk5AnaLRbizOwd34YEUCsGLYvMwinzeemoDt6jUgojJhZDnytFzvaIutEqCaXSW72c6X4TQ==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-11.1.0.tgz",
+            "integrity": "sha512-YMFZknHKny+cqSsVOlumFlf1jVoKGBn3Fgxf1+Wt0PUsEdE54JCb2Vi8MqrYt6mgf5EEc5E4C1o9DfkrptIDwA==",
             "dev": true,
             "requires": {
+                "@tippyjs/react": "4.1.0",
                 "@vxna/mini-html-webpack-template": "^1.0.0",
                 "acorn": "^6.4.1",
                 "acorn-jsx": "^5.1.0",
                 "ast-types": "~0.13.2",
-                "buble": "0.19.8",
+                "buble": "0.20.0",
                 "clean-webpack-plugin": "^3.0.0",
                 "clipboard-copy": "^3.1.0",
                 "clsx": "^1.0.4",
                 "common-dir": "^3.0.0",
-                "copy-webpack-plugin": "^5.1.0",
+                "copy-webpack-plugin": "^6.1.0",
                 "core-js": "^3.6.4",
                 "doctrine": "^3.0.0",
                 "es6-object-assign": "~1.1.0",
                 "es6-promise": "^4.2.8",
                 "escodegen": "^1.12.0",
                 "estree-walker": "~0.9.0",
+                "fastest-levenshtein": "^1.0.9",
                 "findup": "^0.1.5",
                 "function.name-polyfill": "^1.0.6",
                 "github-slugger": "^1.2.1",
@@ -12050,7 +12273,6 @@
                 "jss-plugin-isolate": "^10.0.0",
                 "jss-plugin-nested": "^10.0.0",
                 "kleur": "^3.0.3",
-                "leven": "^3.1.0",
                 "listify": "^1.0.0",
                 "loader-utils": "^2.0.0",
                 "lodash": "^4.17.15",
@@ -12073,11 +12295,11 @@
                 "recast": "~0.18.5",
                 "remark": "^11.0.1",
                 "strip-html-comments": "^1.0.0",
-                "terser-webpack-plugin": "^2.2.1",
+                "terser-webpack-plugin": "^4.1.0",
                 "to-ast": "^1.0.0",
                 "type-detect": "^4.0.8",
                 "unist-util-visit": "^2.0.0",
-                "webpack-dev-server": "^3.9.0",
+                "webpack-dev-server": "^3.11.0",
                 "webpack-merge": "^4.2.2"
             },
             "dependencies": {
@@ -12089,6 +12311,36 @@
                     "requires": {
                         "@babel/highlight": "^7.0.0"
                     }
+                },
+                "@nodelib/fs.stat": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+                    "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+                    "dev": true
+                },
+                "@types/json-schema": {
+                    "version": "7.0.6",
+                    "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+                    "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+                    "dev": true
+                },
+                "ajv": {
+                    "version": "6.12.5",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+                    "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "3.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+                    "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+                    "dev": true
                 },
                 "ansi-regex": {
                     "version": "5.0.0",
@@ -12106,6 +12358,21 @@
                         "color-convert": "^2.0.1"
                     }
                 },
+                "array-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
                 "browserslist": {
                     "version": "4.7.0",
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
@@ -12118,28 +12385,27 @@
                     }
                 },
                 "cacache": {
-                    "version": "13.0.1",
-                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-                    "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+                    "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
                     "dev": true,
                     "requires": {
-                        "chownr": "^1.1.2",
-                        "figgy-pudding": "^3.5.1",
+                        "@npmcli/move-file": "^1.0.1",
+                        "chownr": "^2.0.0",
                         "fs-minipass": "^2.0.0",
                         "glob": "^7.1.4",
-                        "graceful-fs": "^4.2.2",
                         "infer-owner": "^1.0.4",
-                        "lru-cache": "^5.1.1",
-                        "minipass": "^3.0.0",
+                        "lru-cache": "^6.0.0",
+                        "minipass": "^3.1.1",
                         "minipass-collect": "^1.0.2",
                         "minipass-flush": "^1.0.5",
                         "minipass-pipeline": "^1.2.2",
-                        "mkdirp": "^0.5.1",
-                        "move-concurrently": "^1.0.1",
-                        "p-map": "^3.0.0",
+                        "mkdirp": "^1.0.3",
+                        "p-map": "^4.0.0",
                         "promise-inflight": "^1.0.1",
-                        "rimraf": "^2.7.1",
-                        "ssri": "^7.0.0",
+                        "rimraf": "^3.0.2",
+                        "ssri": "^8.0.0",
+                        "tar": "^6.0.2",
                         "unique-filename": "^1.1.1"
                     }
                 },
@@ -12152,6 +12418,12 @@
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
                     }
+                },
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+                    "dev": true
                 },
                 "cli-cursor": {
                     "version": "3.1.0",
@@ -12192,14 +12464,55 @@
                     "integrity": "sha512-f0QqPLpRTgMQn/pQIynf+SdE73Lw5Q1jn4hjirHLgH/NJ71TiHjXusV16BmOyuK5rRQ1W2f++II+TFZbQOh4hA==",
                     "dev": true
                 },
-                "dir-glob": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-                    "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+                "copy-webpack-plugin": {
+                    "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.1.1.tgz",
+                    "integrity": "sha512-4TlkHFYkrZ3WppLA5XkPmBLI5lnEpFsXvpeqxCf5PzkratZiVklNXsvoQkLhUU43q7ZL3AOXtaHAd9jLNJoU0w==",
                     "dev": true,
                     "requires": {
-                        "arrify": "^1.0.1",
-                        "path-type": "^3.0.0"
+                        "cacache": "^15.0.5",
+                        "fast-glob": "^3.2.4",
+                        "find-cache-dir": "^3.3.1",
+                        "glob-parent": "^5.1.1",
+                        "globby": "^11.0.1",
+                        "loader-utils": "^2.0.0",
+                        "normalize-path": "^3.0.0",
+                        "p-limit": "^3.0.2",
+                        "schema-utils": "^2.7.1",
+                        "serialize-javascript": "^5.0.1",
+                        "webpack-sources": "^1.4.3"
+                    }
+                },
+                "dir-glob": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+                    "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+                    "dev": true,
+                    "requires": {
+                        "path-type": "^4.0.0"
+                    }
+                },
+                "fast-glob": {
+                    "version": "3.2.4",
+                    "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+                    "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@nodelib/fs.stat": "^2.0.2",
+                        "@nodelib/fs.walk": "^1.2.3",
+                        "glob-parent": "^5.1.0",
+                        "merge2": "^1.3.0",
+                        "micromatch": "^4.0.2",
+                        "picomatch": "^2.2.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
                     }
                 },
                 "find-cache-dir": {
@@ -12214,12 +12527,13 @@
                     }
                 },
                 "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "global-modules": {
@@ -12243,18 +12557,17 @@
                     }
                 },
                 "globby": {
-                    "version": "8.0.2",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
-                    "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+                    "version": "11.0.1",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+                    "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
                     "dev": true,
                     "requires": {
-                        "array-union": "^1.0.1",
-                        "dir-glob": "2.0.0",
-                        "fast-glob": "^2.0.2",
-                        "glob": "^7.1.2",
-                        "ignore": "^3.3.5",
-                        "pify": "^3.0.0",
-                        "slash": "^1.0.0"
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.1.1",
+                        "ignore": "^5.1.4",
+                        "merge2": "^1.3.0",
+                        "slash": "^3.0.0"
                     }
                 },
                 "has-flag": {
@@ -12264,9 +12577,9 @@
                     "dev": true
                 },
                 "ignore": {
-                    "version": "3.3.10",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-                    "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
                     "dev": true
                 },
                 "inquirer": {
@@ -12397,11 +12710,28 @@
                         }
                     }
                 },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
                 "is-root": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
                     "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==",
                     "dev": true
+                },
+                "jest-worker": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+                    "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
                 },
                 "kleur": {
                     "version": "3.0.3",
@@ -12421,13 +12751,12 @@
                     }
                 },
                 "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "log-symbols": {
@@ -12497,6 +12826,15 @@
                     "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
                     "dev": true
                 },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
                 "make-dir": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -12506,10 +12844,26 @@
                         "semver": "^6.0.0"
                     }
                 },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
                 "mimic-fn": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
                     "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
                     "dev": true
                 },
                 "mute-stream": {
@@ -12519,18 +12873,18 @@
                     "dev": true
                 },
                 "onetime": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+                    "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
                     "dev": true,
                     "requires": {
                         "mimic-fn": "^2.1.0"
                     }
                 },
                 "ora": {
-                    "version": "4.0.4",
-                    "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
-                    "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+                    "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
                     "dev": true,
                     "requires": {
                         "chalk": "^3.0.0",
@@ -12544,27 +12898,59 @@
                     }
                 },
                 "p-limit": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+                    "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
                     }
                 },
                 "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^2.0.0"
+                        "p-limit": "^2.2.0"
+                    },
+                    "dependencies": {
+                        "p-limit": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                            "dev": true,
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "p-map": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+                    "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+                    "dev": true,
+                    "requires": {
+                        "aggregate-error": "^3.0.0"
                     }
                 },
                 "p-try": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
                     "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
                     "dev": true
                 },
                 "pify": {
@@ -12580,42 +12966,6 @@
                     "dev": true,
                     "requires": {
                         "find-up": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "find-up": {
-                            "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                            "dev": true,
-                            "requires": {
-                                "locate-path": "^5.0.0",
-                                "path-exists": "^4.0.0"
-                            }
-                        },
-                        "locate-path": {
-                            "version": "5.0.0",
-                            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                            "dev": true,
-                            "requires": {
-                                "p-locate": "^4.1.0"
-                            }
-                        },
-                        "p-locate": {
-                            "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                            "dev": true,
-                            "requires": {
-                                "p-limit": "^2.2.0"
-                            }
-                        },
-                        "path-exists": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                            "dev": true
-                        }
                     }
                 },
                 "react-dev-utils": {
@@ -12651,6 +13001,12 @@
                         "text-table": "0.2.0"
                     },
                     "dependencies": {
+                        "@nodelib/fs.stat": {
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+                            "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+                            "dev": true
+                        },
                         "ansi-regex": {
                             "version": "4.1.0",
                             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -12664,6 +13020,44 @@
                             "dev": true,
                             "requires": {
                                 "color-convert": "^1.9.0"
+                            }
+                        },
+                        "array-union": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                            "dev": true,
+                            "requires": {
+                                "array-uniq": "^1.0.1"
+                            }
+                        },
+                        "braces": {
+                            "version": "2.3.2",
+                            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                            "dev": true,
+                            "requires": {
+                                "arr-flatten": "^1.1.0",
+                                "array-unique": "^0.3.2",
+                                "extend-shallow": "^2.0.1",
+                                "fill-range": "^4.0.0",
+                                "isobject": "^3.0.1",
+                                "repeat-element": "^1.1.2",
+                                "snapdragon": "^0.8.1",
+                                "snapdragon-node": "^2.0.1",
+                                "split-string": "^3.0.2",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
                             }
                         },
                         "chalk": {
@@ -12692,17 +13086,135 @@
                             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
                             "dev": true
                         },
+                        "dir-glob": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+                            "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+                            "dev": true,
+                            "requires": {
+                                "arrify": "^1.0.1",
+                                "path-type": "^3.0.0"
+                            }
+                        },
                         "emojis-list": {
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
                             "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
                             "dev": true
                         },
+                        "fast-glob": {
+                            "version": "2.2.7",
+                            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+                            "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+                            "dev": true,
+                            "requires": {
+                                "@mrmlnc/readdir-enhanced": "^2.2.1",
+                                "@nodelib/fs.stat": "^1.1.2",
+                                "glob-parent": "^3.1.0",
+                                "is-glob": "^4.0.0",
+                                "merge2": "^1.2.3",
+                                "micromatch": "^3.1.10"
+                            }
+                        },
+                        "fill-range": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                            "dev": true,
+                            "requires": {
+                                "extend-shallow": "^2.0.1",
+                                "is-number": "^3.0.0",
+                                "repeat-string": "^1.6.1",
+                                "to-regex-range": "^2.1.0"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "find-up": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "^3.0.0"
+                            }
+                        },
+                        "glob-parent": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                            "dev": true,
+                            "requires": {
+                                "is-glob": "^3.1.0",
+                                "path-dirname": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "is-glob": {
+                                    "version": "3.1.0",
+                                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extglob": "^2.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "globby": {
+                            "version": "8.0.2",
+                            "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+                            "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+                            "dev": true,
+                            "requires": {
+                                "array-union": "^1.0.1",
+                                "dir-glob": "2.0.0",
+                                "fast-glob": "^2.0.2",
+                                "glob": "^7.1.2",
+                                "ignore": "^3.3.5",
+                                "pify": "^3.0.0",
+                                "slash": "^1.0.0"
+                            }
+                        },
                         "has-flag": {
                             "version": "3.0.0",
                             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                             "dev": true
+                        },
+                        "ignore": {
+                            "version": "3.3.10",
+                            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+                            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+                            "dev": true
+                        },
+                        "is-number": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
                         },
                         "json5": {
                             "version": "1.0.1",
@@ -12724,6 +13236,76 @@
                                 "json5": "^1.0.1"
                             }
                         },
+                        "locate-path": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                            "dev": true,
+                            "requires": {
+                                "p-locate": "^3.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "micromatch": {
+                            "version": "3.1.10",
+                            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                            "dev": true,
+                            "requires": {
+                                "arr-diff": "^4.0.0",
+                                "array-unique": "^0.3.2",
+                                "braces": "^2.3.1",
+                                "define-property": "^2.0.2",
+                                "extend-shallow": "^3.0.2",
+                                "extglob": "^2.0.4",
+                                "fragment-cache": "^0.2.1",
+                                "kind-of": "^6.0.2",
+                                "nanomatch": "^1.2.9",
+                                "object.pick": "^1.3.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.2"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                            "dev": true,
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "^2.0.0"
+                            }
+                        },
+                        "path-exists": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                            "dev": true
+                        },
+                        "path-type": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                            "dev": true,
+                            "requires": {
+                                "pify": "^3.0.0"
+                            }
+                        },
+                        "slash": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+                            "dev": true
+                        },
                         "strip-ansi": {
                             "version": "5.2.0",
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -12741,6 +13323,16 @@
                             "requires": {
                                 "has-flag": "^3.0.0"
                             }
+                        },
+                        "to-regex-range": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                            "dev": true,
+                            "requires": {
+                                "is-number": "^3.0.0",
+                                "repeat-string": "^1.6.1"
+                            }
                         }
                     }
                 },
@@ -12749,15 +13341,6 @@
                     "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
                     "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==",
                     "dev": true
-                },
-                "react-group": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/react-group/-/react-group-3.0.2.tgz",
-                    "integrity": "sha512-0Jy99MD27jHSJ0PeynomUM0WArxywdcqQUKLttBWV6KYH+zlKWT/RhDwVxrODtMkRxf644BzuJFie1Hvfun7jA==",
-                    "dev": true,
-                    "requires": {
-                        "prop-types": "^15.7.2"
-                    }
                 },
                 "react-simple-code-editor": {
                     "version": "0.10.0",
@@ -12775,6 +13358,26 @@
                         "signal-exit": "^3.0.2"
                     }
                 },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "schema-utils": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+                    "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.5",
+                        "ajv": "^6.12.4",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -12782,18 +13385,18 @@
                     "dev": true
                 },
                 "serialize-javascript": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-                    "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+                    "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
                     "dev": true,
                     "requires": {
                         "randombytes": "^2.1.0"
                     }
                 },
                 "slash": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
                     "dev": true
                 },
                 "source-map": {
@@ -12803,12 +13406,11 @@
                     "dev": true
                 },
                 "ssri": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-                    "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+                    "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
                     "dev": true,
                     "requires": {
-                        "figgy-pudding": "^3.5.1",
                         "minipass": "^3.1.1"
                     }
                 },
@@ -12822,30 +13424,56 @@
                     }
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
                 },
-                "terser-webpack-plugin": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.6.tgz",
-                    "integrity": "sha512-I8IDsQwZrqjdmOicNeE8L/MhwatAap3mUrtcAKJuilsemUNcX+Hier/eAzwStVqhlCxq0aG3ni9bK/0BESXkTg==",
+                "terser": {
+                    "version": "5.3.2",
+                    "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.2.tgz",
+                    "integrity": "sha512-H67sydwBz5jCUA32ZRL319ULu+Su1cAoZnnc+lXnenGRYWyLE3Scgkt8mNoAsMx0h5kdo758zdoS0LG9rYZXDQ==",
                     "dev": true,
                     "requires": {
-                        "cacache": "^13.0.1",
+                        "commander": "^2.20.0",
+                        "source-map": "~0.6.1",
+                        "source-map-support": "~0.5.12"
+                    }
+                },
+                "terser-webpack-plugin": {
+                    "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-4.2.2.tgz",
+                    "integrity": "sha512-3qAQpykRTD5DReLu5/cwpsg7EZFzP3Q0Hp2XUWJUw2mpq2jfgOKTZr8IZKKnNieRVVo1UauROTdhbQJZveGKtQ==",
+                    "dev": true,
+                    "requires": {
+                        "cacache": "^15.0.5",
                         "find-cache-dir": "^3.3.1",
-                        "jest-worker": "^25.4.0",
-                        "p-limit": "^2.3.0",
-                        "schema-utils": "^2.6.6",
-                        "serialize-javascript": "^3.0.0",
+                        "jest-worker": "^26.3.0",
+                        "p-limit": "^3.0.2",
+                        "schema-utils": "^2.7.1",
+                        "serialize-javascript": "^5.0.1",
                         "source-map": "^0.6.1",
-                        "terser": "^4.6.12",
+                        "terser": "^5.3.2",
                         "webpack-sources": "^1.4.3"
                     }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
                 }
             }
         },
@@ -12984,6 +13612,12 @@
                 "source-map": "~0.6.1"
             },
             "dependencies": {
+                "ast-types": {
+                    "version": "0.13.3",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
+                    "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
+                    "dev": true
+                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13431,6 +14065,12 @@
             "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
             "dev": true
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rewrite-imports": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/rewrite-imports/-/rewrite-imports-2.0.3.tgz",
@@ -13448,15 +14088,6 @@
             "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
             "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
             "dev": true
-        },
-        "right-align": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-            "dev": true,
-            "requires": {
-                "align-text": "^0.1.1"
-            }
         },
         "rimraf": {
             "version": "2.7.1",
@@ -13481,6 +14112,12 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
             "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+            "dev": true
+        },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
             "dev": true
         },
         "run-queue": {
@@ -13675,10 +14312,13 @@
             }
         },
         "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-            "dev": true
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
         },
         "serve-index": {
             "version": "1.9.1",
@@ -14326,6 +14966,12 @@
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
             "dev": true
         },
+        "string-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+            "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+            "dev": true
+        },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -14604,6 +15250,40 @@
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
             "dev": true
         },
+        "tar": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+            "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+            "dev": true,
+            "requires": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
+            }
+        },
         "term-size": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -14683,16 +15363,16 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-            "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+            "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
             "dev": true,
             "requires": {
                 "cacache": "^12.0.2",
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.2",
+                "serialize-javascript": "^4.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",
@@ -14708,6 +15388,15 @@
                         "ajv": "^6.1.0",
                         "ajv-errors": "^1.0.0",
                         "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "serialize-javascript": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+                    "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+                    "dev": true,
+                    "requires": {
+                        "randombytes": "^2.1.0"
                     }
                 },
                 "source-map": {
@@ -14815,6 +15504,15 @@
             "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
             "dev": true
         },
+        "tippy.js": {
+            "version": "6.2.6",
+            "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.2.6.tgz",
+            "integrity": "sha512-0tTL3WQNT0nWmpslhDryRahoBm6PT9fh1xXyDfOsvZpDzq52by2rF2nvsW0WX2j9nUZP/jSGDqfKJGjCtoGFKg==",
+            "dev": true,
+            "requires": {
+                "@popperjs/core": "^2.4.4"
+            }
+        },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14909,9 +15607,9 @@
             "dev": true
         },
         "token-stream": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-            "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+            "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=",
             "dev": true
         },
         "toposort": {
@@ -15060,13 +15758,6 @@
                 }
             }
         },
-        "uglify-to-browserify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-            "dev": true,
-            "optional": true
-        },
         "unherit": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
@@ -15213,9 +15904,9 @@
             }
         },
         "unist-util-visit": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
-            "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+            "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
             "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
@@ -15230,9 +15921,9 @@
                     "dev": true
                 },
                 "unist-util-visit-parents": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
-                    "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.0.tgz",
+                    "integrity": "sha512-0g4wbluTF93npyPrp/ymd3tCDTMnP0yo2akFD2FIBAYXq/Sga3lwaU1D8OYKbtpioaI6CkDcQ6fsMnmtzt7htw==",
                     "dev": true,
                     "requires": {
                         "@types/unist": "^2.0.0",
@@ -15506,9 +16197,9 @@
             }
         },
         "vfile": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
-            "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
+            "integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
             "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
@@ -15549,9 +16240,9 @@
             "dev": true
         },
         "void-elements": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-            "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+            "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
             "dev": true
         },
         "vue": {
@@ -15588,26 +16279,28 @@
             }
         },
         "vue-docgen-api": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/vue-docgen-api/-/vue-docgen-api-4.24.0.tgz",
-            "integrity": "sha512-alb0lJSUMEaMxQw6/THemXnwCUVQGsFhR9VyrCmkHe2LpoIB8dfLgqTK9DrsGJS0iCy/qVWxeflr+ybgQREXpA==",
+            "version": "4.32.4",
+            "resolved": "https://registry.npmjs.org/vue-docgen-api/-/vue-docgen-api-4.32.4.tgz",
+            "integrity": "sha512-dtPOg9uCnclBOiWASMDMBjYhrXbRDlADZNTMkc5NtF1eSXzltN7GvB7P3YO92M5IvUeHwq84A9BqGBBbye5oWg==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.6.0",
                 "@babel/types": "^7.6.0",
-                "ast-types": "^0.12.2",
+                "@vue/compiler-dom": "^3.0.0-rc.6",
+                "@vue/compiler-sfc": "^3.0.0-rc.6",
+                "ast-types": "0.13.3",
                 "hash-sum": "^1.0.2",
                 "lru-cache": "^4.1.5",
-                "pug": "^2.0.3",
-                "recast": "^0.17.3",
+                "pug": "^3.0.0",
+                "recast": "0.19.1",
                 "ts-map": "^1.0.3",
-                "vue-template-compiler": "^2.0.0"
+                "vue-inbrowser-compiler-utils": "^4.32.1"
             },
             "dependencies": {
                 "ast-types": {
-                    "version": "0.12.4",
-                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.4.tgz",
-                    "integrity": "sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw==",
+                    "version": "0.13.3",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
+                    "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
                     "dev": true
                 },
                 "hash-sum": {
@@ -15627,12 +16320,12 @@
                     }
                 },
                 "recast": {
-                    "version": "0.17.6",
-                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.6.tgz",
-                    "integrity": "sha512-yoQRMRrK1lszNtbkGyM4kN45AwylV5hMiuEveUBlxytUViWevjvX6w+tzJt1LH4cfUhWt4NZvy3ThIhu6+m5wQ==",
+                    "version": "0.19.1",
+                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.19.1.tgz",
+                    "integrity": "sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==",
                     "dev": true,
                     "requires": {
-                        "ast-types": "0.12.4",
+                        "ast-types": "0.13.3",
                         "esprima": "~4.0.0",
                         "private": "^0.1.8",
                         "source-map": "~0.6.1"
@@ -15702,23 +16395,47 @@
             "dev": true
         },
         "vue-inbrowser-compiler": {
-            "version": "4.23.3",
-            "resolved": "https://registry.npmjs.org/vue-inbrowser-compiler/-/vue-inbrowser-compiler-4.23.3.tgz",
-            "integrity": "sha512-ac5wMcvH0dpSeE2TsO7dY9zkyJ9UBB6R7U0IMsyWf6j1xSeHavCFtuOOQwphobLYlPqvneK1DoMwhVkDVm/fkQ==",
+            "version": "4.32.1",
+            "resolved": "https://registry.npmjs.org/vue-inbrowser-compiler/-/vue-inbrowser-compiler-4.32.1.tgz",
+            "integrity": "sha512-eHNJ6fenrTISxS2t540eB6K7O4AcZX7x73ZHHkK78sGAFeRDaxB17gEqtPPY2mgSi124gEy1I0MzFo+cHEJNSA==",
             "dev": true,
             "requires": {
                 "acorn": "^6.1.1",
                 "acorn-jsx": "^5.0.1",
                 "buble": "^0.19.7",
                 "camelcase": "^5.3.1",
-                "vue-inbrowser-compiler-utils": "^4.23.3",
+                "vue-inbrowser-compiler-utils": "^4.32.1",
                 "walkes": "^0.2.1"
+            },
+            "dependencies": {
+                "buble": {
+                    "version": "0.19.8",
+                    "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
+                    "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^6.1.1",
+                        "acorn-dynamic-import": "^4.0.0",
+                        "acorn-jsx": "^5.0.1",
+                        "chalk": "^2.4.2",
+                        "magic-string": "^0.25.3",
+                        "minimist": "^1.2.0",
+                        "os-homedir": "^2.0.0",
+                        "regexpu-core": "^4.5.4"
+                    }
+                },
+                "os-homedir": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
+                    "integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q==",
+                    "dev": true
+                }
             }
         },
         "vue-inbrowser-compiler-utils": {
-            "version": "4.23.3",
-            "resolved": "https://registry.npmjs.org/vue-inbrowser-compiler-utils/-/vue-inbrowser-compiler-utils-4.23.3.tgz",
-            "integrity": "sha512-//NgjTyi9E2zEbVaXnkOHqKEpuCQ67HrEfvfLjBeuy9VOy07jH26FbdBG/bL3zA/iwXiHdiePSa1+YdvSyCKpA==",
+            "version": "4.32.1",
+            "resolved": "https://registry.npmjs.org/vue-inbrowser-compiler-utils/-/vue-inbrowser-compiler-utils-4.32.1.tgz",
+            "integrity": "sha512-IL8rBV3lCyHErqD8sBdQhWz3zJ/wLzG6JfoSzZ3K6HShS5QqIQfJN0GESvzIos6EGvmtByEf4TTJnjm12b51VQ==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.3.1"
@@ -15764,13 +16481,13 @@
             }
         },
         "vue-styleguidist": {
-            "version": "4.24.0",
-            "resolved": "https://registry.npmjs.org/vue-styleguidist/-/vue-styleguidist-4.24.0.tgz",
-            "integrity": "sha512-WH9ANTJn7vfGM+fMQwl1iQrpaK4VhPK8oyxf7fpY7V1xvOdvrhsqRzSnmVeGSyQIw/+mNAg3R/OKHUtt028h8w==",
+            "version": "4.32.4",
+            "resolved": "https://registry.npmjs.org/vue-styleguidist/-/vue-styleguidist-4.32.4.tgz",
+            "integrity": "sha512-TNTNphOvOO6caoj3R9CSK0sOuRiAEUFt2zTg2fXYqeEUhIwzBTaxK047XQ5z50a4MABv2XORy3cwy522kdEAaQ==",
             "dev": true,
             "requires": {
                 "@vxna/mini-html-webpack-template": "^1.0.0",
-                "ast-types": "^0.13.2",
+                "ast-types": "^0.13.3",
                 "classnames": "^2.2.6",
                 "clean-webpack-plugin": "^3.0.0",
                 "cli-progress": "^3.0.0",
@@ -15808,22 +16525,28 @@
                 "react-codemirror2": "^5.1.0",
                 "react-dev-utils": "^7.0.3",
                 "react-dom": "^16.8.0",
-                "react-group": "^1.0.6",
+                "react-group": "^3.0.2",
                 "react-icons": "^3.7.0",
                 "react-lifecycles-compat": "^3.0.4",
                 "react-simple-code-editor": "^0.11.0",
-                "react-styleguidist": "^11.0.6",
+                "react-styleguidist": "^11.0.9",
                 "rewrite-imports": "^2.0.3",
                 "style-loader": "^1.0.0",
                 "terser-webpack-plugin": "^2.2.2",
                 "to-ast": "^1.0.0",
-                "vue-docgen-api": "^4.24.0",
-                "vue-inbrowser-compiler": "^4.23.3",
-                "vue-inbrowser-compiler-utils": "^4.23.3",
+                "vue-docgen-api": "^4.32.4",
+                "vue-inbrowser-compiler": "^4.32.1",
+                "vue-inbrowser-compiler-utils": "^4.32.1",
                 "webpack-dev-server": "^3.11.0",
                 "webpack-merge": "^4.0.0"
             },
             "dependencies": {
+                "@types/json-schema": {
+                    "version": "7.0.6",
+                    "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+                    "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+                    "dev": true
+                },
                 "cacache": {
                     "version": "13.0.1",
                     "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
@@ -16036,15 +16759,6 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 },
-                "serialize-javascript": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
-                    "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
-                    "dev": true,
-                    "requires": {
-                        "randombytes": "^2.1.0"
-                    }
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -16062,9 +16776,9 @@
                     }
                 },
                 "terser-webpack-plugin": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.6.tgz",
-                    "integrity": "sha512-I8IDsQwZrqjdmOicNeE8L/MhwatAap3mUrtcAKJuilsemUNcX+Hier/eAzwStVqhlCxq0aG3ni9bK/0BESXkTg==",
+                    "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
+                    "integrity": "sha512-/fKw3R+hWyHfYx7Bv6oPqmk4HGQcrWLtV3X6ggvPuwPNHSnzvVV51z6OaaCOus4YLjutYGOz3pEpbhe6Up2s1w==",
                     "dev": true,
                     "requires": {
                         "cacache": "^13.0.1",
@@ -16072,21 +16786,39 @@
                         "jest-worker": "^25.4.0",
                         "p-limit": "^2.3.0",
                         "schema-utils": "^2.6.6",
-                        "serialize-javascript": "^3.0.0",
+                        "serialize-javascript": "^4.0.0",
                         "source-map": "^0.6.1",
                         "terser": "^4.6.12",
                         "webpack-sources": "^1.4.3"
                     },
                     "dependencies": {
-                        "schema-utils": {
-                            "version": "2.7.0",
-                            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-                            "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+                        "ajv": {
+                            "version": "6.12.5",
+                            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+                            "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
                             "dev": true,
                             "requires": {
-                                "@types/json-schema": "^7.0.4",
-                                "ajv": "^6.12.2",
-                                "ajv-keywords": "^3.4.1"
+                                "fast-deep-equal": "^3.1.1",
+                                "fast-json-stable-stringify": "^2.0.0",
+                                "json-schema-traverse": "^0.4.1",
+                                "uri-js": "^4.2.2"
+                            }
+                        },
+                        "ajv-keywords": {
+                            "version": "3.5.2",
+                            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+                            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+                            "dev": true
+                        },
+                        "schema-utils": {
+                            "version": "2.7.1",
+                            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+                            "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+                            "dev": true,
+                            "requires": {
+                                "@types/json-schema": "^7.0.5",
+                                "ajv": "^6.12.4",
+                                "ajv-keywords": "^3.5.2"
                             }
                         }
                     }
@@ -16155,15 +16887,71 @@
             "dev": true
         },
         "watchpack": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",
-            "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+            "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
             "dev": true,
             "requires": {
-                "chokidar": "^3.4.0",
+                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
                 "neo-async": "^2.5.0",
                 "watchpack-chokidar2": "^2.0.0"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.4.2",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+                    "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "~3.1.1",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.1.2",
+                        "glob-parent": "~5.1.0",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.4.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true,
+                    "optional": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
             }
         },
         "watchpack-chokidar2": {
@@ -16300,9 +17088,9 @@
             }
         },
         "webpack": {
-            "version": "4.43.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
-            "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
+            "version": "4.44.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+            "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.9.0",
@@ -16313,7 +17101,7 @@
                 "ajv": "^6.10.2",
                 "ajv-keywords": "^3.4.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^4.1.0",
+                "enhanced-resolve": "^4.3.0",
                 "eslint-scope": "^4.0.3",
                 "json-parse-better-errors": "^1.0.2",
                 "loader-runner": "^2.4.0",
@@ -16326,7 +17114,7 @@
                 "schema-utils": "^1.0.0",
                 "tapable": "^1.1.3",
                 "terser-webpack-plugin": "^1.4.3",
-                "watchpack": "^1.6.1",
+                "watchpack": "^1.7.4",
                 "webpack-sources": "^1.4.1"
             },
             "dependencies": {
@@ -16771,40 +17559,22 @@
                 "string-width": "^2.1.1"
             }
         },
-        "window-size": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-            "dev": true
-        },
         "with": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-            "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+            "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
             "dev": true,
             "requires": {
-                "acorn": "^3.1.0",
-                "acorn-globals": "^3.0.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                    "dev": true
-                }
+                "@babel/parser": "^7.9.6",
+                "@babel/types": "^7.9.6",
+                "assert-never": "^1.2.1",
+                "babel-walk": "3.0.0-canary-5"
             }
         },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true
-        },
-        "wordwrap": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
             "dev": true
         },
         "worker-farm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16116,9 +16116,9 @@
             "dev": true
         },
         "vuetify": {
-            "version": "2.2.31",
-            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.2.31.tgz",
-            "integrity": "sha512-Ad9NgJr6S7iOd9oMtzOfswEQG4dmVOWaAMSk+3T5oSveVBiSWVLG5F0jVHL9Pe8VblcT4L4EXsTldGT9P3BzLA=="
+            "version": "2.3.10",
+            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.3.10.tgz",
+            "integrity": "sha512-KzL/MhZ7ajubm9kwbdCoA/cRV50RX+a5Hcqiwt7Am1Fni2crDtl2no05UNwKroTfscrYYf07gq3WIFSurPsnCA=="
         },
         "vuetify-loader": {
             "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "main": "index.js",
     "dependencies": {
         "vue": "^2.5.17",
-        "vuetify": "^2.2.31"
+        "vuetify": "^2.3.10"
     },
     "devDependencies": {
         "@vue/cli-plugin-babel": "^4.4.1",

--- a/src/components/VSnackbarQueue.vue
+++ b/src/components/VSnackbarQueue.vue
@@ -15,23 +15,27 @@
             v-for="(item, i) in items"
         >
             {{ item.message }}
-            <v-btn
-                :color="nextButtonColor"
-                @click="removeItem(item.id)"
-                text
-                v-if="items.length > 1"
-            >
-                {{nextButtonText}} ({{items.length - 1}} more)
-            </v-btn>
-            <v-btn
-                :color="closeButtonColor"
-                @click="removeItem(item.id)"
-                text
-                icon
-                v-else
-            >
-                <v-icon>{{closeButtonIcon}}</v-icon>
-            </v-btn>
+            <template v-slot:action="{ attrs }">
+                <v-btn
+                    :color="nextButtonColor"
+                    @click="removeItem(item.id)"
+                    text
+                    v-bind="attrs"
+                    v-if="items.length > 1"
+                >
+                    {{nextButtonText}} ({{items.length - 1}} more)
+                </v-btn>
+                <v-btn
+                    :color="closeButtonColor"
+                    @click="removeItem(item.id)"
+                    text
+                    icon
+                    v-bind="attrs"
+                    v-else
+                >
+                    <v-icon>{{closeButtonIcon}}</v-icon>
+                </v-btn>
+            </template>
         </v-snackbar>
     </div>
 </template>


### PR DESCRIPTION
Security update with npm audit fix
Bumped vuetify to 2.3.10.
Refactored component for use with Vuetify 2.3.*
For use actions in snackbar, now need a slot actios.

[Vuetify Release](https://github.com/vuetifyjs/vuetify/releases/tag/v2.3.0)